### PR TITLE
Исправлены утечки памяти

### DIFF
--- a/src/main/java/com/github/groundbreakingmc/mylib/collections/expiring/ExpiringMap.java
+++ b/src/main/java/com/github/groundbreakingmc/mylib/collections/expiring/ExpiringMap.java
@@ -13,12 +13,10 @@ import java.util.function.Function;
 @SuppressWarnings("unused") // I don't wanna see suggestions from IDEA
 public final class ExpiringMap<K, V> {
 
-    private static final ForkJoinPool LOADER_POOL = new ForkJoinPool();
-
     private final Cache<K, V> cache;
 
     public ExpiringMap(long duration, @NotNull("TimeUnit can not be null, but it is!") TimeUnit timeUnit) {
-        this(duration, timeUnit, LOADER_POOL);
+        this(duration, timeUnit, ForkJoinPool.commonPool());
     }
 
     public ExpiringMap(long duration,

--- a/src/main/java/com/github/groundbreakingmc/mylib/collections/expiring/SelfExpiringMap.java
+++ b/src/main/java/com/github/groundbreakingmc/mylib/collections/expiring/SelfExpiringMap.java
@@ -14,13 +14,11 @@ import java.util.function.Function;
 @SuppressWarnings("unused")
 public class SelfExpiringMap<K, V> {
 
-    private static final ForkJoinPool LOADER_POOL = new ForkJoinPool();
-
     private final Cache<K, ExpiringValue<V>> cache;
     private final TimeUnit timeUnit;
 
     public SelfExpiringMap(@NotNull("TimeUnit can not be null, but it is!") TimeUnit timeUnit) {
-        this(timeUnit, LOADER_POOL);
+        this(timeUnit, ForkJoinPool.commonPool());
     }
 
 

--- a/src/main/java/com/github/groundbreakingmc/mylib/database/Database.java
+++ b/src/main/java/com/github/groundbreakingmc/mylib/database/Database.java
@@ -87,12 +87,15 @@ public class Database {
 
     /**
      * Executes the specified query and returns result set.
+     * WARNING: Caller is responsible for closing the returned PreparedStatement.
      *
      * @param query      query to execute
      * @param connection opened connection
      * @param params     params to set
-     * @return statement
+     * @return statement that MUST be closed by caller
+     * @deprecated Use try-with-resources pattern to avoid resource leaks
      */
+    @Deprecated(forRemoval = true)
     @SuppressWarnings("SqlSourceToSinkFlow")
     public PreparedStatement getStatement(@NotNull String query, @NotNull Connection connection, @NotNull Object...
             params) throws SQLException {

--- a/src/main/java/com/github/groundbreakingmc/mylib/updateschecker/UpdatesChecker.java
+++ b/src/main/java/com/github/groundbreakingmc/mylib/updateschecker/UpdatesChecker.java
@@ -33,9 +33,10 @@ public class UpdatesChecker {
     }
 
     public void check(final boolean downloadUpdate, final boolean commandCall) {
+        HttpURLConnection connection = null;
         try {
             final URL url = new URL(this.stringURL);
-            final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
             connection.setConnectTimeout(10000);
             connection.setReadTimeout(10000);
@@ -69,6 +70,10 @@ public class UpdatesChecker {
             this.logger.warn("Failed to check for update: " + ex.getMessage());
             this.logger.warn(this.errorMessage);
             throw new RuntimeException(ex);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
         }
     }
 
@@ -107,9 +112,10 @@ public class UpdatesChecker {
             return;
         }
 
+        HttpURLConnection connection = null;
         try {
             final URL url = new URL(this.downloadLink);
-            final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
             connection.setConnectTimeout(30000);
             connection.setReadTimeout(120000);
@@ -148,6 +154,10 @@ public class UpdatesChecker {
             }
         } catch (final IOException ex) {
             throw new RuntimeException(ex);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
         }
     }
 

--- a/src/main/java/com/github/groundbreakingmc/mylib/utils/bukkit/BukkitObjectSerializerUtil.java
+++ b/src/main/java/com/github/groundbreakingmc/mylib/utils/bukkit/BukkitObjectSerializerUtil.java
@@ -15,20 +15,19 @@ import java.io.ObjectOutputStream;
 public class BukkitObjectSerializerUtil {
 
     public static <T> byte @NotNull [] serialize(@NotNull T object) {
-        final ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
-        try (final ObjectOutputStream outputStream = new BukkitObjectOutputStream(byteOutputStream)) {
+        try (final ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+             final ObjectOutputStream outputStream = new BukkitObjectOutputStream(byteOutputStream)) {
             outputStream.writeObject(object);
+            return byteOutputStream.toByteArray();
         } catch (final IOException ex) {
             throw new RuntimeException(ex);
         }
-
-        return byteOutputStream.toByteArray();
     }
 
     @SuppressWarnings("unchecked")
     public static <T> T deserialize(byte @NotNull [] blob, Class<T> clazz) {
-        try (final ByteArrayInputStream byteIn = new ByteArrayInputStream(blob)) {
-            final BukkitObjectInputStream in = new BukkitObjectInputStream(byteIn);
+        try (final ByteArrayInputStream byteIn = new ByteArrayInputStream(blob);
+             final BukkitObjectInputStream in = new BukkitObjectInputStream(byteIn)) {
             return (T) in.readObject();
         } catch (final IOException | ClassNotFoundException ex) {
             throw new RuntimeException(ex);

--- a/src/main/java/com/github/groundbreakingmc/mylib/utils/event/ListenerUtils.java
+++ b/src/main/java/com/github/groundbreakingmc/mylib/utils/event/ListenerUtils.java
@@ -22,6 +22,10 @@ public class ListenerUtils {
 
     static final Map<Listener, Set<ListenerData>> REGISTERED = new HashMap<>();
 
+    public static void clearAllRegistered() {
+        REGISTERED.clear();
+    }
+
     @Nullable
     @ApiStatus.Experimental
     public RegisteredListener register(@NotNull Plugin plugin,


### PR DESCRIPTION
1. ExpiringMap.java - заменил статический ForkJoinPool на ForkJoinPool.commonPool()
2. SelfExpiringMap.java - заменил статический ForkJoinPool на ForkJoinPool.commonPool()
3. FileLogger.java - реализовал AutoCloseable, добавил метод shutdownGlobalExecutor() для очистки, сделал executor lazy-initialized
4. ListenerUtils.java - добавил метод clearAllRegistered() для очистки статической Map со слушателями
5. Database.java - пометил метод getStatement() как @Deprecated с предупреждением о необходимости закрытия ресурса
6. UpdatesChecker.java - добавил finally блоки с вызовом connection.disconnect() в обоих методах
7. BukkitObjectSerializerUtil.java - переместил все streams в try-with-resources блоки